### PR TITLE
ffbab.conf: Remove opkg main download link.

### DIFF
--- a/domains/ffbab.conf
+++ b/domains/ffbab.conf
@@ -4,7 +4,6 @@
 	hide_domain = true,
 
 	opkg = {
-		openwrt = 'http://downloads.openwrt.org/%n/%v/%S/packages',
 		extra = {
 			modules = 'http://firmware.services.ffffm.net/babel-dev/sysupgrade/modules/gluon-%GS-%GR/%S',
 		},


### PR DESCRIPTION
Wenn die Zeile 
```
openwrt = 'http://downloads.openwrt.org/%n/%v/%S/packages',
```
entfernt wird, wird der Default-Link aus den Gluon-Sourcen verwendet.
Unabhängig der Gluon-Basis  (LEDE bzw. OpenWrt)