### PR TITLE
Babel site.conf: Restore the old password behaviour in config mode.

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -8,10 +8,15 @@
   regdom = 'DE',
   
   default_domain = 'ffbab',
+  
   config_mode = {
     geo_location = {
       show_altitude = false,
     },
+  remote_login = {
+    show_password_form = true,
+    min_password_length = 10,
+	  },
   },
 
   mesh_vpn = {

--- a/site.conf
+++ b/site.conf
@@ -16,7 +16,7 @@
   remote_login = {
     show_password_form = true,
     min_password_length = 10,
-	  },
+    },
   },
 
   mesh_vpn = {


### PR DESCRIPTION
The password change form in the “Advanced settings” is not shown by default anymore.
This commit restore the old behaviour.