### PR TITLE
Switch remaining nodes from IBSS to 11s

### DIFF
--- a/domains/legacybat_11s.conf
+++ b/domains/legacybat_11s.conf
@@ -1,0 +1,100 @@
+{
+  -- multiple codes/names can be defined, the first one is the primary name
+  -- additional aliases can be defined
+  domain_names = {
+    legacybat_11s = 'Legacy Batman v14 - 802.11s',
+  -- auffangbecken = 'Auffangbecken',
+  },
+
+  -- 32 byte random data in hexadecimal encoding
+  -- This data must be unique among all sites and domains!
+  -- Can be generated using: echo $(hexdump -v -n 32 -e '1/1 "%02x"' </dev/urandom)
+  domain_seed = 'f3a8cea77298c398d3edca83e8f786637dc6533d94f45a9401691ff8c1be7e22',
+
+  -- Because of the legacy domain vxlan is be turned off.
+  mesh = {
+    vxlan = false,
+  },
+
+  -- unique network prefixes per domain
+  prefix4 = '10.126.0.0/16',
+  prefix6 = 'fddd:5d16:b5dd:0::/64',
+  extra_prefixes6 = { '2a06:8187:fb00::/40', },
+
+  next_node = {
+    name = { 'nextnode', 'nn' },
+    ip4 = '10.126.0.1',
+    ip6 = 'fddd:5d16:b5dd::1',
+    mac = '16:41:95:40:f7:dc',
+  },
+
+  wifi24 = {
+    ap = {
+      ssid = 'ffm.freifunk.net',
+    },
+    mesh = {
+      disabled = false,
+      id = '802.11s:FFFFM:BATMAN',
+      mcast_rate = 12000,
+    },
+  },
+
+  wifi5 = {
+    ap = {
+      ssid = 'ffm.freifunk.net',
+    },
+    mesh = {
+      disabled = false,
+      id = '802.11s:FFFFM:BATMAN',
+      mcast_rate = 12000,
+    },
+  },
+
+  mesh_vpn = {
+    fastd = {
+      groups = {
+        backbone = {
+          limit = 1,
+          peers = {
+            fastd1 = {
+              key = '6d98ed09fc260a65234a65b03ce47c9e1a19226c66220c66b89255bf569fa68b',
+              remotes = {'"fastd1.ffm.freifunk.net" port 10003'},
+            },
+            fastd2 = {
+              key = '9a539d2761a3533b09d01065fb995b6488612ec50d61787703c0fe94a9f79967',
+              remotes = {'"fastd2.ffm.freifunk.net" port 10003'},
+            },
+            fastd3 = {
+              key = 'e16542b789ebb2f8ec258ee5f1a359ff2852ff5740fe802a35299e711ac57982',
+              remotes = {'"fastd3.ffm.freifunk.net" port 10003'},
+            },
+            fastd4 = {
+              key = 'e9d48b3ffa7593a736288bbb7e6f32daf9d0df4c5d03ddbadb9b7d04c334ece8',
+              remotes = {'"fastd4.ffm.freifunk.net" port 10003'},
+              },
+            fastd5 = {
+              key = '4235016b554520600d866d34fb7cccf48e7f8c8c5954ec473fabb6fd22c60ecf',
+              remotes = {'"fastd5.ffm.freifunk.net" port 10003'},
+            },
+            fastd6 = {
+              key = 'e5c9fee48ca3b3e0a5ca59854672dfc238e1068cc1008897148fada1f9590392',
+              remotes = {'"fastd6.ffm.freifunk.net" port 10003'},
+            },
+            fastd7 = {
+              key = '541ad0b39c10a21337f85f8c721276200f095a8df5196e97c0b6e05128df0983',
+              remotes = {'"fastd7.ffm.freifunk.net" port 10003'},
+            },
+            fastd8 = {
+              key = '55d23f51067cf83967b991cf06fee710d59b0c26d184529eb319405a5e37782e',
+              remotes = {'"fastd8.ffm.freifunk.net" port 10003'},
+            },
+            fastd9 = {
+              key = '7300f366e15a797a8451b1d7a37ddfe8b617c6eed6fcea3c517023c43318c4fa',
+              remotes = {'"fastd9.ffm.freifunk.net" port 10003'},
+            },
+          },
+        },
+      },
+    },
+  },
+}

--- a/domains/legacybat_ibss.conf
+++ b/domains/legacybat_ibss.conf
@@ -16,6 +16,16 @@
     vxlan = false,
   },
 
+  domain_switch = {
+    target_domain = 'legacybat_11s',
+    switch_after_offline_mins = 120,
+    switch_time = 1567360800, -- 01.09.2019 - 20:00 CEST
+    connection_check_targets = {
+      '2a06:8187:fb56::1:56',
+      '2a06:8187:fb56::1:57',
+    },
+  },
+
   -- unique network prefixes per domain
   prefix4 = '10.126.0.0/16',
   prefix6 = 'fddd:5d16:b5dd:0::/64',

--- a/domains/legacybat_ibss.conf
+++ b/domains/legacybat_ibss.conf
@@ -19,7 +19,7 @@
   domain_switch = {
     target_domain = 'legacybat_11s',
     switch_after_offline_mins = 120,
-    switch_time = 1567530000, -- 03.09.2019 - 19:00 CEST
+    switch_time = 1568012400, -- 09.09.2019 - 09:00 CEST
     connection_check_targets = {
       '2a06:8187:fb56::1:56',
       '2a06:8187:fb56::1:57',

--- a/domains/legacybat_ibss.conf
+++ b/domains/legacybat_ibss.conf
@@ -19,7 +19,7 @@
   domain_switch = {
     target_domain = 'legacybat_11s',
     switch_after_offline_mins = 120,
-    switch_time = 1567360800, -- 01.09.2019 - 20:00 CEST
+    switch_time = 1567530000, -- 03.09.2019 - 19:00 CEST
     connection_check_targets = {
       '2a06:8187:fb56::1:56',
       '2a06:8187:fb56::1:57',

--- a/domains/legacybat_ibss.conf
+++ b/domains/legacybat_ibss.conf
@@ -1,0 +1,102 @@
+{
+  -- multiple codes/names can be defined, the first one is the primary name
+  -- additional aliases can be defined
+  domain_names = {
+  legacybat_ibss = 'Legacy Batman v14 - IBSS',
+  -- auffangbecken = 'Auffangbecken',
+  },
+
+  -- 32 byte random data in hexadecimal encoding
+  -- This data must be unique among all sites and domains!
+  -- Can be generated using: echo $(hexdump -v -n 32 -e '1/1 "%02x"' </dev/urandom)
+  domain_seed = 'f3a8cea77298c398d3edca83e8f786637dc6533d94f45a9401691ff8c1be7e22',
+
+  -- Because of the legacy domain vxlan is be turned off.
+  mesh = {
+    vxlan = false,
+  },
+
+  -- unique network prefixes per domain
+  prefix4 = '10.126.0.0/16',
+  prefix6 = 'fddd:5d16:b5dd:0::/64',
+  extra_prefixes6 = { '2a06:8187:fb00::/40', },
+
+  next_node = {
+    name = { 'nextnode', 'nn' },
+    ip4 = '10.126.0.1',
+    ip6 = 'fddd:5d16:b5dd::1',
+    mac = '16:41:95:40:f7:dc',
+  },
+
+  wifi24 = {
+    ap = {
+      ssid = 'ffm.freifunk.net',
+    },
+    ibss = {
+      disabled = false,
+      ssid = '02:d1:11:37:fd:42',
+      bssid = '02:d1:11:37:fd:42',
+      mcast_rate = 12000,
+    },
+  },
+
+  wifi5 = {
+    ap = {
+      ssid = 'ffm.freifunk.net',
+    },
+    ibss = {
+      disabled = false,
+      ssid = '02:d1:11:37:fd:42',
+      bssid = '02:d1:11:37:fd:42',
+      mcast_rate = 12000,
+    },
+  },
+
+  mesh_vpn = {
+    fastd = {
+      groups = {
+        backbone = {
+          limit = 1,
+          peers = {
+            fastd1 = {
+              key = '6d98ed09fc260a65234a65b03ce47c9e1a19226c66220c66b89255bf569fa68b',
+              remotes = {'"fastd1.ffm.freifunk.net" port 10003'},
+            },
+            fastd2 = {
+              key = '9a539d2761a3533b09d01065fb995b6488612ec50d61787703c0fe94a9f79967',
+              remotes = {'"fastd2.ffm.freifunk.net" port 10003'},
+            },
+            fastd3 = {
+              key = 'e16542b789ebb2f8ec258ee5f1a359ff2852ff5740fe802a35299e711ac57982',
+              remotes = {'"fastd3.ffm.freifunk.net" port 10003'},
+            },
+            fastd4 = {
+              key = 'e9d48b3ffa7593a736288bbb7e6f32daf9d0df4c5d03ddbadb9b7d04c334ece8',
+              remotes = {'"fastd4.ffm.freifunk.net" port 10003'},
+              },
+            fastd5 = {
+              key = '4235016b554520600d866d34fb7cccf48e7f8c8c5954ec473fabb6fd22c60ecf',
+              remotes = {'"fastd5.ffm.freifunk.net" port 10003'},
+            },
+            fastd6 = {
+              key = 'e5c9fee48ca3b3e0a5ca59854672dfc238e1068cc1008897148fada1f9590392',
+              remotes = {'"fastd6.ffm.freifunk.net" port 10003'},
+            },
+            fastd7 = {
+              key = '541ad0b39c10a21337f85f8c721276200f095a8df5196e97c0b6e05128df0983',
+              remotes = {'"fastd7.ffm.freifunk.net" port 10003'},
+            },
+            fastd8 = {
+              key = '55d23f51067cf83967b991cf06fee710d59b0c26d184529eb319405a5e37782e',
+              remotes = {'"fastd8.ffm.freifunk.net" port 10003'},
+            },
+            fastd9 = {
+              key = '7300f366e15a797a8451b1d7a37ddfe8b617c6eed6fcea3c517023c43318c4fa',
+              remotes = {'"fastd9.ffm.freifunk.net" port 10003'},
+            },
+          },
+        },
+      },
+    },
+  },
+}

--- a/site.conf
+++ b/site.conf
@@ -2,11 +2,7 @@
   hostname_prefix = 'Postleitzahl-',
   site_name = 'Freifunk Frankfurt',
   site_code = 'ffffm',
-  domain_seed = 'f3a8cea77298c398d3edca83e8f786637dc6533d94f45a9401691ff8c1be7e22',
-
-  prefix4 = '10.126.0.0/16',
-  prefix6 = 'fddd:5d16:b5dd:0::/64',
-  extra_prefixes6 = { '2a06:8187:fb00::/40', },
+  default_domain = 'legacybat_ibss',
 
   timezone = 'CET-1CEST,M3.5.0,M10.5.0/3', -- Europe/Berlin
   ntp_servers = {'ntp.services.ffffm.net'},
@@ -14,52 +10,15 @@
 
   wifi24 = {
     channel = 1,
-    supported_rates = {6000, 9000, 12000, 18000, 24000, 36000, 48000, 54000},
-    basic_rate = {6000, 9000, 18000, 36000, 54000},
-    ap = {
-      ssid = 'ffm.freifunk.net',
-    },
---  mesh = {
---    disabled = true,
---    id = '802.11s:FFFFM:BATMAN',
---    mcast_rate = 12000,
---  },    
-    ibss = {
-      disabled = false,
-      ssid = '02:d1:11:37:fd:42',
-      bssid = '02:d1:11:37:fd:42',
-      mcast_rate = 12000,
-    },
   },
-  
+
   wifi5 = {
     channel = 44,
     outdoor_chanlist = '100-140',
-    ap = {
-      ssid = 'ffm.freifunk.net',
-    },
---  mesh = {
---    disabled = true,
---    id = '802.11s:FFFFM:BATMAN',
---    mcast_rate = 12000,
---  },    
-    ibss = {
-      disabled = false,
-      ssid = '02:d1:11:37:fd:42',
-      bssid = '02:d1:11:37:fd:42',
-      mcast_rate = 12000,
-    },
   },
 
   dns = {
     servers = { '2a06:8187:fb56::1:56', '2a06:8187:fb57::1:57', },
-  },
-
-  next_node = {
-    name = { 'nextnode', 'nn' },
-    ip4 = '10.126.0.1',
-    ip6 = 'fddd:5d16:b5dd::1',
-    mac = '16:41:95:40:f7:dc',
   },
 
   config_mode = {
@@ -76,10 +35,6 @@
 	},
   },
 
-  mesh = {
-    vxlan = false,
-  },
-
   mesh_vpn = {
     enabled = true,
     mesh_on_wan = false,
@@ -88,54 +43,11 @@
     fastd = {
       methods = {'salsa2012+umac'},
       configurable = false,
-      groups = {
-        backbone = {
-          limit = 1,
-          peers = {
-            fastd1 = {
-              key = '6d98ed09fc260a65234a65b03ce47c9e1a19226c66220c66b89255bf569fa68b',
-              remotes = {'"fastd1.ffm.freifunk.net" port 10003'},
-            },
-            fastd2 = {
-              key = '9a539d2761a3533b09d01065fb995b6488612ec50d61787703c0fe94a9f79967',
-              remotes = {'"fastd2.ffm.freifunk.net" port 10003'},
-            },
-            fastd3 = {
-              key = 'e16542b789ebb2f8ec258ee5f1a359ff2852ff5740fe802a35299e711ac57982',
-              remotes = {'"fastd3.ffm.freifunk.net" port 10003'},
-            },
-            fastd4 = {
-              key = 'e9d48b3ffa7593a736288bbb7e6f32daf9d0df4c5d03ddbadb9b7d04c334ece8',
-              remotes = {'"fastd4.ffm.freifunk.net" port 10003'},
-              },
-            fastd5 = {
-              key = '4235016b554520600d866d34fb7cccf48e7f8c8c5954ec473fabb6fd22c60ecf',
-              remotes = {'"fastd5.ffm.freifunk.net" port 10003'},
-            },
-            fastd6 = {
-              key = 'e5c9fee48ca3b3e0a5ca59854672dfc238e1068cc1008897148fada1f9590392',
-              remotes = {'"fastd6.ffm.freifunk.net" port 10003'},
-            },
-            fastd7 = {
-              key = '541ad0b39c10a21337f85f8c721276200f095a8df5196e97c0b6e05128df0983',
-              remotes = {'"fastd7.ffm.freifunk.net" port 10003'},
-            },
-            fastd8 = {
-              key = '55d23f51067cf83967b991cf06fee710d59b0c26d184529eb319405a5e37782e',
-              remotes = {'"fastd8.ffm.freifunk.net" port 10003'},
-            },
-            fastd9 = {
-              key = '7300f366e15a797a8451b1d7a37ddfe8b617c6eed6fcea3c517023c43318c4fa',
-              remotes = {'"fastd9.ffm.freifunk.net" port 10003'},
-            },
-          },
-        },
-      },
     },
     bandwidth_limit = {
       -- The bandwidth limit can be enabled by default here.
       enabled = false,
-      egress = 500,   -- 0,5 Mbit/s   
+      egress = 500,   -- 0,5 Mbit/s
       ingress = 5000, -- 5,0 Mbit/s
     },
   },
@@ -195,6 +107,16 @@
     },
   },
 
+  domain_switch = {
+    target_domain = 'legacybat_11s',
+    switch_after_offline_mins = 120,
+    switch_time = 1567360800, -- 01.09.2019 - 20:00 CEST
+    connection_check_targets = {
+      '2a06:8187:fb56::1:56',
+      '2a06:8187:fb56::1:57',
+    },
+  },
+
   ssid_changer = {             -- https://github.com/ffac/gluon-ssid-changer/tree/2018.1.x
     enabled = true,
     switch_timeframe = 2,
@@ -213,4 +135,3 @@
   },
 
 }
-

--- a/site.conf
+++ b/site.conf
@@ -104,16 +104,6 @@
     },
   },
 
-  domain_switch = {
-    target_domain = 'legacybat_11s',
-    switch_after_offline_mins = 120,
-    switch_time = 1567360800, -- 01.09.2019 - 20:00 CEST
-    connection_check_targets = {
-      '2a06:8187:fb56::1:56',
-      '2a06:8187:fb56::1:57',
-    },
-  },
-
   ssid_changer = {             -- https://github.com/ffac/gluon-ssid-changer/tree/2018.1.x
     enabled = true,
     switch_timeframe = 2,

--- a/site.conf
+++ b/site.conf
@@ -65,11 +65,10 @@
         pubkeys = {
           '4180213b3112df3fc3d1e40ea715e7145e04340261ee9f23eea9aaaa495c254a', -- Jenkins
           '22d81f93bd797f33f9a64c65c62ebfbc7c1117a5e4a477fb5b0f6e309e94d926', -- Christof
-          '6c7da1d3b6441e650571f3881d4c2276ce22219bec7ac5809b070fdf04d7d91f', -- Jan
-          '2a61930930a240c027f6ca4197203d400b6e4a32f9e92041e5f086907796c9bc', -- jha
-          '0ebac3d341673dbeb8b6d2499811ce7851516aae851d71067a3e16488dee44c7', -- magnus
+          '0ebac3d341673dbeb8b6d2499811ce7851516aae851d71067a3e16488dee44c7', -- Magnus
           '9a5ceee2ba63dbe8f8d1db3dc3e90050a08b54c9c37858722be9f082841d857f', -- Juergen S.
           '19504c9dbfa9436a51de4cc59a078bbe3aa73ebd8636852d49fc65495d099b0d', -- Igor
+          'acead4f6f335c7bea4455935dbcabf86c6c6452b8be89aad11ed705cf7496ea8', -- Marvin
         },
       },
       test = {
@@ -81,11 +80,10 @@
         pubkeys = {
           '4180213b3112df3fc3d1e40ea715e7145e04340261ee9f23eea9aaaa495c254a', -- Jenkins
           '22d81f93bd797f33f9a64c65c62ebfbc7c1117a5e4a477fb5b0f6e309e94d926', -- Christof
-          '6c7da1d3b6441e650571f3881d4c2276ce22219bec7ac5809b070fdf04d7d91f', -- Jan
-          '2a61930930a240c027f6ca4197203d400b6e4a32f9e92041e5f086907796c9bc', -- jha
-          '0ebac3d341673dbeb8b6d2499811ce7851516aae851d71067a3e16488dee44c7', -- magnus
+          '0ebac3d341673dbeb8b6d2499811ce7851516aae851d71067a3e16488dee44c7', -- Magnus
           '9a5ceee2ba63dbe8f8d1db3dc3e90050a08b54c9c37858722be9f082841d857f', -- Juergen S.
           '19504c9dbfa9436a51de4cc59a078bbe3aa73ebd8636852d49fc65495d099b0d', -- Igor
+          'acead4f6f335c7bea4455935dbcabf86c6c6452b8be89aad11ed705cf7496ea8', -- Marvin
         },
       },
       dev = {
@@ -97,11 +95,10 @@
         pubkeys = {
           '4180213b3112df3fc3d1e40ea715e7145e04340261ee9f23eea9aaaa495c254a', -- Jenkins
           '22d81f93bd797f33f9a64c65c62ebfbc7c1117a5e4a477fb5b0f6e309e94d926', -- Christof
-          '6c7da1d3b6441e650571f3881d4c2276ce22219bec7ac5809b070fdf04d7d91f', -- Jan
-          '2a61930930a240c027f6ca4197203d400b6e4a32f9e92041e5f086907796c9bc', -- jha
-          '0ebac3d341673dbeb8b6d2499811ce7851516aae851d71067a3e16488dee44c7', -- magnus
+          '0ebac3d341673dbeb8b6d2499811ce7851516aae851d71067a3e16488dee44c7', -- Magnus
           '9a5ceee2ba63dbe8f8d1db3dc3e90050a08b54c9c37858722be9f082841d857f', -- Juergen S.
           '19504c9dbfa9436a51de4cc59a078bbe3aa73ebd8636852d49fc65495d099b0d', -- Igor
+          'acead4f6f335c7bea4455935dbcabf86c6c6452b8be89aad11ed705cf7496ea8', -- Marvin
         },
       },
     },

--- a/site.conf
+++ b/site.conf
@@ -59,7 +59,7 @@
       stable = {
         name = 'stable',
         mirrors = {
-          'http://updates.services.ffffm/stable/sysupgrade',
+          'http://updates.services.ffffm.net/stable/sysupgrade',
         },
         good_signatures = 3,
         pubkeys = {
@@ -74,7 +74,7 @@
       test = {
         name = 'test',
         mirrors = {
-          'http://updates.services.ffffm/test/sysupgrade',
+          'http://updates.services.ffffm.net/test/sysupgrade',
         },
         good_signatures = 2,
         pubkeys = {
@@ -89,7 +89,7 @@
       dev = {
         name = 'dev',
         mirrors = {
-          'http://updates.services.ffffm/dev/sysupgrade',
+          'http://updates.services.ffffm.net/dev/sysupgrade',
         },
         good_signatures = 1,
         pubkeys = {
@@ -127,7 +127,7 @@
 
   opkg = {
     extra = {
-      modules = 'http://updates.services.ffffm/stable/sysupgrade/modules/gluon-%GS-%GR/%S',
+      modules = 'http://updates.services.ffffm.net/test/sysupgrade/modules/gluon-%GS-%GR/%S',
     },
   },
 

--- a/site.mk
+++ b/site.mk
@@ -39,7 +39,7 @@ GLUON_MULTIDOMAIN := 1
 # This is the Stable branch
 
 # Gluon Base Release
-DEFAULT_GLUON_RELEASE := vHomebrew-stable
+DEFAULT_GLUON_RELEASE := v3.1.2
 
 # For homebrew development add e.g. date and time
 # (Note: Don't use the ':' char. It will break the build)
@@ -49,7 +49,7 @@ DEFAULT_GLUON_RELEASE := $(DEFAULT_GLUON_RELEASE)-$(shell date '+%Y.%m.%d')
 GLUON_RELEASE ?= $(DEFAULT_GLUON_RELEASE)
 
 # Development branch information
-GLUON_BRANCH ?= stable
+GLUON_BRANCH ?= test
 
 # Default priority for updates.
 GLUON_PRIORITY ?= 0

--- a/site.mk
+++ b/site.mk
@@ -39,7 +39,7 @@ GLUON_MULTIDOMAIN := 1
 # This is the Stable branch
 
 # Gluon Base Release
-DEFAULT_GLUON_RELEASE := v3.1.2
+DEFAULT_GLUON_RELEASE := v3.2
 
 # For homebrew development add e.g. date and time
 # (Note: Don't use the ':' char. It will break the build)
@@ -49,7 +49,7 @@ DEFAULT_GLUON_RELEASE := $(DEFAULT_GLUON_RELEASE)-$(shell date '+%Y.%m.%d')
 GLUON_RELEASE ?= $(DEFAULT_GLUON_RELEASE)
 
 # Development branch information
-GLUON_BRANCH ?= test
+GLUON_BRANCH ?= stable
 
 # Default priority for updates.
 GLUON_PRIORITY ?= 0

--- a/site.mk
+++ b/site.mk
@@ -9,6 +9,7 @@ GLUON_FEATURES := \
 	radvd \
 	radv-filterd \
 	respondd \
+	scheduled-domain-switch \
 	status-page \
 	web-advanced \
 	web-wizard \
@@ -28,7 +29,10 @@ GLUON_SITE_PACKAGES := \
 	respondd-module-airtime \
 
 
-include $(GLUON_SITEDIR)/specific_site.mk 
+include $(GLUON_SITEDIR)/specific_site.mk
+
+# Enable multidomain support
+GLUON_MULTIDOMAIN := 1
 
 #####################################################################################################################
 
@@ -37,7 +41,7 @@ include $(GLUON_SITEDIR)/specific_site.mk
 # Gluon Base Release
 DEFAULT_GLUON_RELEASE := vHomebrew-stable
 
-# For homebrew development add e.g. date and time 
+# For homebrew development add e.g. date and time
 # (Note: Don't use the ':' char. It will break the build)
 DEFAULT_GLUON_RELEASE := $(DEFAULT_GLUON_RELEASE)-$(shell date '+%Y.%m.%d')
 

--- a/site.mk
+++ b/site.mk
@@ -43,7 +43,7 @@ DEFAULT_GLUON_RELEASE := v3.2
 
 # For homebrew development add e.g. date and time
 # (Note: Don't use the ':' char. It will break the build)
-DEFAULT_GLUON_RELEASE := $(DEFAULT_GLUON_RELEASE)-$(shell date '+%Y.%m.%d')
+DEFAULT_GLUON_RELEASE := $(DEFAULT_GLUON_RELEASE)-$(GLUON_BRANCH)-$(shell date '+%m%d')
 
 # Allow overriding the release number from the command line
 GLUON_RELEASE ?= $(DEFAULT_GLUON_RELEASE)


### PR DESCRIPTION
PR, wie auf der ML vorgeschlagen.

Aktuell WIP,

ToDo:

- [x] Test auf 4/32-HW
- [x] Test mit Mesh-Only-Node, der zum Switch-Zeitpunkt offline ist
- [x] Test der Dauerhaftigkeit des Switches (Reboots mit Mesh Only nach Umstellung)
- [ ] Weiterer, Public Test

Changes:
- Add Marvins signature 
- Use `http://updates.services.ffffm.net` as the mirror
- Use GLUON_MULTIDOMAIN
- 1 Domain: IBSS with domain_switch
- 2 Domain: 11s