### PR TITLE
Gluon 2019 (v3.4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 ## Stable-Version der Frankfurter Freifunkfirmware
 
+### v3.4-stable-1006
+- Erstellt am 06.10.2019
+- Neue Hardware und Bugfixes, siehe Gluon 2019.1 Release-Notes
+- x86 benutzt jetzt SquashFS, und kann damit zurückgesetzt werden `firstboot`
+- Basis ist Gluon [v2019.1](https://gluon.readthedocs.io/en/v2019.1/)
+
 ### v3.3.1-stable-2109
 - Erstellt am 21.09.2019
 - letztes Patch-Release von Gluon 2018

--- a/domains/legacybat_11s.conf
+++ b/domains/legacybat_11s.conf
@@ -14,9 +14,9 @@
   -- Because of the legacy domain vxlan is be turned off.
   mesh = {
     vxlan = false,
---    batman_adv = {
---	   routing_algo = 'BATMAN_IV_LEGACY',
---    },
+    batman_adv = {
+	   routing_algo = 'BATMAN_IV_LEGACY',
+    },
   },
 
   -- unique network prefixes per domain

--- a/site.mk
+++ b/site.mk
@@ -38,10 +38,10 @@ GLUON_MULTIDOMAIN := 1
 # This is the Stable branch
 
 # Gluon Base Release
-DEFAULT_GLUON_RELEASE := v3.3.1
+DEFAULT_GLUON_RELEASE := v3.3.2
 
 # Development branch information
-GLUON_BRANCH ?= stable
+GLUON_BRANCH ?= test
 
 DEFAULT_GLUON_RELEASE := $(DEFAULT_GLUON_RELEASE)-$(GLUON_BRANCH)-$(shell date '+%m%d')
 

--- a/site.mk
+++ b/site.mk
@@ -41,7 +41,7 @@ GLUON_MULTIDOMAIN := 1
 DEFAULT_GLUON_RELEASE := v3.4
 
 # Development branch information
-GLUON_BRANCH ?= test
+GLUON_BRANCH ?= stable
 
 DEFAULT_GLUON_RELEASE := $(DEFAULT_GLUON_RELEASE)-$(GLUON_BRANCH)-$(shell date '+%m%d')
 

--- a/site.mk
+++ b/site.mk
@@ -38,7 +38,7 @@ GLUON_MULTIDOMAIN := 1
 # This is the Stable branch
 
 # Gluon Base Release
-DEFAULT_GLUON_RELEASE := v3.3.2
+DEFAULT_GLUON_RELEASE := v3.4
 
 # Development branch information
 GLUON_BRANCH ?= test


### PR DESCRIPTION
- [x]  Build v3.4-Test
- [x]  Discuss final version number
- [x]  Test on devices and announce test availability
- [x]  Release Checklist
- [ ]  Release Notes
- [x]  Stable Build
- [x]  Merge, Tag & Rollout

Changes:
See Gluon v2019.1 Release Notes (https://gluon.readthedocs.io/en/latest/releases/v2019.1.html)